### PR TITLE
Treating the board as a first-class entity

### DIFF
--- a/examples/firmata_blink_led.rb
+++ b/examples/firmata_blink_led.rb
@@ -4,7 +4,7 @@ require 'artoo'
 
 #connection :firmata, :adaptor => :firmata, :port => '/dev/tty*'
 connection :firmata, :adaptor => :firmata, :port => '127.0.0.1:8023'
-device :board
+device :board, :driver => :firmata_board
 device :led, :driver => :led, :pin => 13
 
 work do

--- a/examples/firmata_blink_led_with_toggle.rb
+++ b/examples/firmata_blink_led_with_toggle.rb
@@ -4,7 +4,7 @@ require 'artoo'
 
 #connection :firmata, :adaptor => :firmata, :port => '/dev/tty*'
 connection :firmata, :adaptor => :firmata, :port => '127.0.0.1:8023'
-device :board 
+device :board, :driver => :firmata_board
 device :led, :driver => :led, :pin => 13
 
 work do

--- a/examples/firmata_dc_motor_speed.rb
+++ b/examples/firmata_dc_motor_speed.rb
@@ -4,7 +4,7 @@ require 'artoo'
 
 #connection :firmata, :adaptor => :firmata, :port => '/dev/tty*'
 connection :firmata, :adaptor => :firmata, :port => '127.0.0.1:8023'
-device :board
+device :board, :driver => :firmata_board
 device :motor, :driver => :motor, :pin => [nil, nil, 3] # Needs a PWM pin
 
 work do

--- a/examples/firmata_led_brightness.rb
+++ b/examples/firmata_led_brightness.rb
@@ -4,7 +4,7 @@ require 'artoo'
 
 #connection :firmata, :adaptor => :firmata, :port => '/dev/tty*'
 connection :firmata, :adaptor => :firmata, :port => '127.0.0.1:8023'
-device :board
+device :board, :driver => :firmata_board
 device :led, :driver => :led, :pin => 3
 
 brightness = 0

--- a/examples/firmata_motor.rb
+++ b/examples/firmata_motor.rb
@@ -9,7 +9,7 @@ forward = true
 
 #connection :firmata, :adaptor => :firmata, :port => '/dev/tty*'
 connection :firmata, :adaptor => :firmata, :port => '127.0.0.1:8023'
-device :board
+device :board, :driver => :firmata_board
 device :motor, :driver => :motor, :pin => [leg1_pin, leg2_pin, speed_pin]
 
 work do

--- a/lib/artoo/drivers/firmata_board.rb
+++ b/lib/artoo/drivers/firmata_board.rb
@@ -1,0 +1,10 @@
+require 'artoo/drivers/driver'
+
+module Artoo
+  module Drivers
+    # Board driver behaviors for Firmata
+    class FirmataBoard < Driver
+      COMMANDS = [:firmware_name, :version].freeze
+    end
+  end
+end

--- a/test/drivers/firmata_board_test.rb
+++ b/test/drivers/firmata_board_test.rb
@@ -1,0 +1,21 @@
+require File.expand_path(File.dirname(__FILE__) + "/../test_helper")
+require 'artoo/drivers/firmata_board'
+
+describe Artoo::Drivers::FirmataBoard do
+  before do
+    @device = mock('device')
+    @board = Artoo::Drivers::FirmataBoard.new(:parent => @device)
+    @connection = mock('connection')
+    @device.stubs(:connection).returns(@connection)
+  end
+    
+  it 'FirmataBoard#firmware_name' do
+    @connection.expects(:firmware_name).returns("awesomenessware")
+    @board.firmware_name.must_equal "awesomenessware"
+  end
+
+  it 'FirmataBoard#version' do
+    @connection.expects(:version).returns("1.2.3")
+    @board.version.must_equal "1.2.3"
+  end
+end


### PR DESCRIPTION
Treating the arduino board itself  as a first-class entity, and gets rid of warnings too. How can we lose!
