### PR TITLE
Require Bundler when brew installing avrdude.

### DIFF
--- a/lib/artoo/commands/firmata.rb
+++ b/lib/artoo/commands/firmata.rb
@@ -29,7 +29,7 @@ module Artoo
         when :linux
           run('sudo apt-get install avrdude')
         when :macosx
-          require 'bundler'
+          require 'bundler' unless defined?(Bundler)
           Bundler.with_clean_env do
             run("brew install avrdude")
           end

--- a/lib/artoo/commands/firmata.rb
+++ b/lib/artoo/commands/firmata.rb
@@ -29,6 +29,7 @@ module Artoo
         when :linux
           run('sudo apt-get install avrdude')
         when :macosx
+          require 'bundler'
           Bundler.with_clean_env do
             run("brew install avrdude")
           end


### PR DESCRIPTION
I got an error message saying that the Bundler constant had not been initialized. Requiring Bundler seemed to fix the issue. Apologies if there is somewhere else I should have required Bundler; I didn't spend much time looking over the code.
