### PR TITLE
Added missing require

### DIFF
--- a/lib/artoo/commands/arduino.rb
+++ b/lib/artoo/commands/arduino.rb
@@ -1,3 +1,5 @@
+require 'artoo/commands/firmata'
+
 module Artoo
   module Commands
     class Arduino < Artoo::Commands::Firmata


### PR DESCRIPTION
Hi,

I was following the [setup from the Artoo site](http://artoo.io/documentation/platforms/arduino/#HowToConnect).

When I ran `artoo arduino scan` it failed with "uninitialized constant
Artoo::Commands::Firmata". I had a look through and it wasn't being
required anywhere so I added it in.
