### PR TITLE
Fixed typo

### DIFF
--- a/lib/artoo-arduino.rb
+++ b/lib/artoo-arduino.rb
@@ -1,8 +1,7 @@
-require 'lib/artoo/adaptors/firmata'
-require 'lib/artoo/adaptors/littlewire'
+require 'artoo/adaptors/firmata'
 
 %w{ button led motor servo wiichuck wiiclassic wiidriver }.each do |f|
-  require "lib/artoo/drivers/#{f}")
+  require "artoo/drivers/#{f}"
 end
 
-require 'lib/artoo-arduino/version'
+require 'artoo-arduino/version'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,9 @@
+require 'minitest'
 require 'minitest/autorun'
 require 'mocha/setup'
 require 'firmata'
 require 'artoo/robot'
+require 'artoo-arduino'
 
 Celluloid.logger = nil
 


### PR DESCRIPTION
When looking through the source to deal with the issue in #23 I noticed that
there was a typo in the require statement in artoo-arduino. This wasn't
being picked up by the tests because it wasn't being required anywhere
so I added it to the test helper.

Once I did this though, I started getting issues because the require paths
were relative to the project root rather than the lib folder. Removing the `lib/`
meant that the tests started passing again and seems correct in the context
of this gem but I was worried that this cause issues with how it fits in the larger
artoo ecosystem.

One final issue is that it was requiring the littlewire adapter which was extracted
into its own project in 2a3fa12 so I removed it.
