### PR TITLE
Updated Rubinius version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.0.0
   - 1.9.3
   - jruby-1.7.9
-  - rbx-2.1.1
+  - rbx-2.2.7
 matrix:
   allow_failures:
     - rvm: jruby-1.7.9


### PR DESCRIPTION
The RBX builds were failing unexpectedly as bundler could not be found.

https://travis-ci.org/hybridgroup/artoo-arduino/jobs/25281604

Updating to the latest version of Rubinius resolved the issue.
