### PR TITLE
Updated version to 1.4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artoo-arduino (1.4.2)
+    artoo-arduino (1.4.3)
       artoo (>= 1.6.0)
       artoo-gpio
       artoo-i2c


### PR DESCRIPTION
The current version is 1.4.3 but the Gemfile.lock was still referring to 1.4.2
