### PR TITLE
Corrected Firmata link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more information abut Artoo, check out our repo at https://github.com/hybrid
 
 [![Code Climate](https://codeclimate.com/github/hybridgroup/artoo-arduino.png)](https://codeclimate.com/github/hybridgroup/artoo-arduino) [![Build Status](https://travis-ci.org/hybridgroup/artoo-arduino.png?branch=master)](https://travis-ci.org/hybridgroup/artoo-arduino)
 
-This gem makes extensive use of the hybridgroup fork of the firmata gem (https://github.com/hybridgroup/firmata) thanks to [@hardbap](https://github.com/hardbap) with code borrrowed from the arduino_firmata gem (https://github.com/shokai/arduino_firmata) thanks to [@shokai](https://github.com/shokai)
+This gem makes extensive use of the hybridgroup fork of the firmata gem (https://github.com/hybridgroup/ruby-firmata) thanks to [@hardbap](https://github.com/hardbap) with code borrrowed from the arduino_firmata gem (https://github.com/shokai/arduino_firmata) thanks to [@shokai](https://github.com/shokai)
 
 ## Installing
 


### PR DESCRIPTION
Firmata link was to the Cylon.js codebase, and not the Ruby version.
